### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/x/AbstractXConnection.java
+++ b/src/main/java/io/kestra/plugin/x/AbstractXConnection.java
@@ -31,7 +31,7 @@ public abstract class AbstractXConnection extends Task implements RunnableTask<V
         title = "Options",
         description = "The options to set to customize the HTTP client"
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     protected RequestOptions options;
 
     protected HttpConfiguration httpClientConfigurationWithOptions() throws IllegalVariableEvaluationException {
@@ -72,32 +72,39 @@ public abstract class AbstractXConnection extends Task implements RunnableTask<V
     @Builder
     public static class RequestOptions {
         @Schema(title = "Connection timeout", description = "Time allowed to establish a server connection before failing")
+        @PluginProperty(group = "execution")
         private final Property<Duration> connectTimeout;
 
         @Schema(title = "Read timeout", description = "Max time allowed for reading data from the server before failing; defaults to 10s")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> readTimeout = Property.ofValue(Duration.ofSeconds(10));
 
         @Schema(title = "Read idle timeout", description = "How long a read connection may stay idle before closing; defaults to 5 minutes")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> readIdleTimeout = Property.ofValue(Duration.of(5, ChronoUnit.MINUTES));
 
         @Schema(title = "Connection pool idle timeout", description = "How long an idle connection stays in the pool before closure; defaults to 0s")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> connectionPoolIdleTimeout = Property.ofValue(Duration.ofSeconds(0));
 
         @Schema(title = "Max content length", description = "Maximum response size in bytes; defaults to 10 MB")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Integer> maxContentLength = Property.ofValue(1024 * 1024 * 10);
 
         @Schema(title = "Default charset", description = "Charset used for requests when none is specified; defaults to UTF-8")
         @Builder.Default
+        @PluginProperty(group = "advanced")
         private final Property<Charset> defaultCharset = Property.ofValue(StandardCharsets.UTF_8);
 
         @Schema(
             title = "HTTP headers",
             description = "HTTP headers to include in the request"
         )
+        @PluginProperty(group = "advanced")
         public Property<Map<String, String>> headers;
     }
 }

--- a/src/main/java/io/kestra/plugin/x/XExecution.java
+++ b/src/main/java/io/kestra/plugin/x/XExecution.java
@@ -13,6 +13,7 @@ import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -96,12 +97,15 @@ public class XExecution extends XTemplate implements ExecutionInterface {
         description = "Execution to include in the template; defaults to the current execution and should be set to {{ trigger.executionId }} when called from a Flow trigger"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private final Property<String> executionId = Property.ofExpression("{{ execution.id }}");
 
     @Schema(title = "Custom fields", description = "Key-value pairs appended to the rendered template output")
+    @PluginProperty(group = "destination")
     private Property<Map<String, Object>> customFields;
 
     @Schema(title = "Custom message", description = "Optional extra text appended to the template output")
+    @PluginProperty(group = "destination")
     private Property<String> customMessage;
 
     @Override

--- a/src/main/java/io/kestra/plugin/x/XTemplate.java
+++ b/src/main/java/io/kestra/plugin/x/XTemplate.java
@@ -24,6 +24,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString(exclude = { "bearerToken", "consumerKey", "consumerSecret", "accessToken", "accessSecret" })
@@ -36,31 +37,40 @@ public abstract class XTemplate extends AbstractXConnection {
     private static final int MAX_POST_LENGTH = 280;
 
     @Schema(title = "Bearer token", description = "X API bearer token for app-only authentication; overrides OAuth 1.0a credentials when set.")
+    @PluginProperty(group = "connection")
     protected Property<String> bearerToken;
 
     @Schema(title = "OAuth consumer key", description = "OAuth 1.0a consumer key (API key) used when no bearer token is provided.")
+    @PluginProperty(group = "connection")
     protected Property<String> consumerKey;
 
     @Schema(title = "OAuth consumer secret", description = "OAuth 1.0a consumer secret (API secret) required when bearer authentication is not used.")
+    @PluginProperty(group = "connection")
     protected Property<String> consumerSecret;
 
     @Schema(title = "OAuth access token", description = "OAuth 1.0a access token required when bearer authentication is not used.")
+    @PluginProperty(group = "connection")
     protected Property<String> accessToken;
 
     @Schema(title = "OAuth access secret", description = "OAuth 1.0a access token secret required when bearer authentication is not used.")
+    @PluginProperty(group = "connection")
     protected Property<String> accessSecret;
 
     @Schema(title = "Template URI", description = "Classpath Pebble template used to render the post body", hidden = true)
+    @PluginProperty(group = "advanced")
     protected Property<String> templateUri;
 
     @Schema(title = "Template variables", description = "Key-value map rendered and injected into the template before sending")
+    @PluginProperty(group = "advanced")
     protected Property<Map<String, Object>> templateRenderMap;
 
     @Schema(title = "Post text body", description = "Direct post text that bypasses the template; must fit within 280 characters")
+    @PluginProperty(group = "advanced")
     protected Property<String> textBody;
 
     @Schema(title = "Override URL for testing", description = "Optional X API endpoint override; defaults to https://api.x.com/2/tweets")
     @Builder.Default
+    @PluginProperty(group = "connection")
     protected Property<String> url = Property.ofValue("https://api.x.com/2/tweets");
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712