### PR TITLE
refactor: replace deprecated tasks and filters

### DIFF
--- a/src/test/resources/flows/common/main-flow-that-fails.yaml
+++ b/src/test/resources/flows/common/main-flow-that-fails.yaml
@@ -2,4 +2,4 @@ id: main-flow-that-fails
 namespace: io.kestra.tests
 tasks:
   - id: failed
-    type: io.kestra.core.tasks.executions.Fail
+    type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
Replaces deprecated task identifiers and Pebble filters with their current equivalents